### PR TITLE
Default executor now uses new cimg

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -7,11 +7,11 @@ executors:
     description: "The official CircleCI Go Docker image."
     parameters:
       tag:
-        description: "The `circleci/golang` Docker image version tag."
+        description: "The `cimg/go` Docker image version tag."
         type: string
         default: "latest"
     docker:
-      - image: circleci/golang:<< parameters.tag >>
+      - image: cimg/go:<< parameters.tag >>
 
 commands:
   install:


### PR DESCRIPTION
Updated the default executor to use new cimg, solves #1 