### PR TITLE
Add shorthand command to download and cache Go modules

### DIFF
--- a/src/commands/mod-download-cached.yml
+++ b/src/commands/mod-download-cached.yml
@@ -1,0 +1,5 @@
+description: "Download and cache Go modules"
+steps:
+  - go/load-cache
+  - go/mod-download
+  - go/save-cache


### PR DESCRIPTION
`go/load-cache`, `go/mod-download` and `go/save-cache` are often used together.

To facilitate this and decrease repetition even more shall we add this shorthand?