### PR TITLE
Use go.sum as the better cache checksum file. [semver:minor]

### DIFF
--- a/src/commands/load-cache.yml
+++ b/src/commands/load-cache.yml
@@ -7,4 +7,4 @@ parameters:
 steps:
   - restore_cache:
       keys:
-        - << parameters.key >>-{{ checksum "go.mod"  }}
+        - << parameters.key >>-{{ checksum "go.sum"  }}

--- a/src/commands/save-cache.yml
+++ b/src/commands/save-cache.yml
@@ -6,6 +6,6 @@ parameters:
     default: "go-mod"
 steps:
   - save_cache:
-      key: << parameters.key >>-{{ checksum "go.mod"  }}
+      key: << parameters.key >>-{{ checksum "go.sum"  }}
       paths:
         - "$GOPATH/pkg/mod"


### PR DESCRIPTION
Similar to how package.lock is the better checksum file for npm, go.sum
is the preferred file over go.mod for caching.