### PR TITLE
Fix Go cache saving. [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ workflows:
           bot-token-variable: GHI_TOKEN
           bot-user: cpe-bot
           fail-if-semver-not-indicated: true
-          publish-version-tag: false
+          publish-version-tag: true
           requires:
             - integration-test-1
             - integration-test-2

--- a/src/commands/save-cache.yml
+++ b/src/commands/save-cache.yml
@@ -8,4 +8,5 @@ steps:
   - save_cache:
       key: << parameters.key >>-{{ checksum "go.sum"  }}
       paths:
-        - "$GOPATH/pkg/mod"
+        # /home/circleci/go is the GOPATH in the cimg/go Docker image
+        - "/home/circleci/go/pkg/mod"


### PR DESCRIPTION
The path used for saving the cache included the environment variable
(envar) $GOPATH. CircleCI doesn't process evars in cache paths. This
meant that cache saving wasn't actually working. This PR fixes that.

Fixes #31 