### PR TITLE
Macos support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ workflows:
     jobs:
       - integration-test-1
       - integration-test-2
+      - int-test-macos-executor
 
       # publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
@@ -62,6 +63,7 @@ workflows:
           requires:
             - integration-test-1
             - integration-test-2
+            - int-test-macos-executor
           filters:
             branches:
               only: master
@@ -83,6 +85,19 @@ jobs:
   integration-test-2:
     docker:
       - image: cimg/base:stable
+    steps:
+      - run:
+          name: "Check out sample project."
+          command: git clone https://github.com/CircleCI-Public/circleci-demo-go.git ~/project
+      - go/install
+      - go/load-cache:
+          key: "integration"
+      - go/mod-download
+      - go/save-cache:
+          key: "integration"
+  int-test-macos-executor:
+    macos:
+      xcode: "11.5.0"
     steps:
       - run:
           name: "Check out sample project."

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,3 +6,6 @@ description: |
 display:
   source_url: https://github.com/CircleCI-Public/go-orb
   home_url: https://golang.org/
+
+orbs:
+  os-detect: circleci/os-detect@0.2

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,12 +1,25 @@
-description: "Install Go in your build (for amd64 Linux)."
+description: |
+  Install Go in a build. Supports Linux/amd64 and macOS/amd64.
 parameters:
   version:
     description: "The Go version."
     type: string
-    default: "1.13.7"
+    default: "1.14.4"
 steps:
+  - os-detect/init
   - run:
-      name: "Install Go."
+      name: "Install Go"
       command: |
-        curl -sSL "https://dl.google.com/go/go<< parameters.version >>.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/
+        if [[ $OSD_FAMILY == "linux" ]];then
+          curl -sSL "https://dl.google.com/go/go<< parameters.version >>.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/
+        elif [[ $OSD_FAMILY == "darwin" ]];then
+          curl -sSL "https://dl.google.com/go/go<< parameters.version >>.darwin-amd64.tar.gz" | sudo tar -xz -C /usr/local/
+        else
+          echo "OS/platform not supported."
+          exit 1
+        fi
+
         echo "export PATH=$PATH:/usr/local/go/bin" >> $BASH_ENV
+  - run:
+      name: "Verify Go Installation"
+      command: echo "Installed " && go version

--- a/src/commands/load-cache.yml
+++ b/src/commands/load-cache.yml
@@ -7,4 +7,4 @@ parameters:
 steps:
   - restore_cache:
       keys:
-        - << parameters.key >>-{{ checksum "go.sum"  }}
+        - << parameters.key >>-{{ arch }}-{{ checksum "go.sum"  }}

--- a/src/commands/save-cache.yml
+++ b/src/commands/save-cache.yml
@@ -11,6 +11,6 @@ parameters:
     default: "/home/circleci/go/pkg/mod"
 steps:
   - save_cache:
-      key: << parameters.key >>-{{ checksum "go.sum"  }}
+      key: << parameters.key >>-{{ arch }}-{{ checksum "go.sum"  }}
       paths:
         - << parameters.path >>


### PR DESCRIPTION
Adds the ability to install Go on the macOS executor.

A corresponding test was added and `{{ arch }}` was added to the cache key because Go compiled bits are architecture specific.

Closes #37.