### PR TITLE
Cache Go installation. [semver:minor]

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -5,11 +5,44 @@ parameters:
     description: "The Go version."
     type: string
     default: "1.14.4"
+  cache:
+    description: Whether or not to cache the binary.
+    type: boolean
+    default: true
+  cache-key:
+    description: |
+      String to use in cache key. Typically overriden when needed to bust cache.
+    type: string
+    default: "v1"
 steps:
   - os-detect/init
+  - when:
+      condition:
+        equal: [ <<parameters.cache>>, true ]
+      steps:
+        - run:
+            name: "Prep cache restore"
+            command: |
+              $SUDO mkdir -p /usr/local/go
+              $SUDO chown -R $(whoami): /usr/local/go
+        - restore_cache:
+            keys:
+              - go-binary-<<parameters.cache-key>>-<<parameters.version>>-{{ arch }}
   - run:
       name: "Install Go"
       command: |
+        if which go;then
+          if go version | grep "<< parameters.version >>";then
+            echo "Binary already exists, skipping download."
+            exit 0
+          else
+            echo "Go is already install but is the wrong version."
+            echo "Installing the request version instead."
+          fi
+
+          echo "Installing the requested version of Go."
+        fi
+
         if [[ $OSD_FAMILY == "linux" ]];then
           curl -sSL "https://dl.google.com/go/go<< parameters.version >>.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/
         elif [[ $OSD_FAMILY == "darwin" ]];then
@@ -20,6 +53,15 @@ steps:
         fi
 
         echo "export PATH=$PATH:/usr/local/go/bin" >> $BASH_ENV
+        $SUDO chown -R $(whoami): /usr/local/go
   - run:
       name: "Verify Go Installation"
       command: echo "Installed " && go version
+  - when:
+      condition:
+        equal: [ <<parameters.cache>>, true ]
+      steps:
+        - save_cache:
+            key: go-binary-<<parameters.cache-key>>-<<parameters.version>>-{{ arch }}
+            paths:
+              - /usr/local/go


### PR DESCRIPTION
PR 3 of three.

This PR adds the ability for the install job to cache the Go binaries.

Two parameters are added to the command, `cache` and cache-key`. The first set to true buy default and the latter our typically "v1".

The lines that check for an existing Go version were added in order to make sure this PR remains backwards compatible with the v1 series of this orb. Without it, installing on an image with an existing version of Go will soft fail. This means that that version the user didn't want will remain and the specific version wouldn't be installed. I made sure to check for that scenario in this PR.

The `chown` commands are because macOS and Linux have different defaults about which users can write to the `/usr/local/bin` directory. This levels the playing field and ensures that the `restore_cache` command has the correct permission to restore the Go binaries from cache.