### PR TITLE
[semver:patch] Update cimg/go Docker latest image

### DIFF
--- a/src/examples/go-modules-cache.yml
+++ b/src/examples/go-modules-cache.yml
@@ -13,7 +13,7 @@ usage:
     build:
       executor:
         name: go/default
-        tag: "1.14"
+        tag: "1.15"
       steps:
         - checkout
         - go/load-cache

--- a/src/examples/test.yml
+++ b/src/examples/test.yml
@@ -14,7 +14,7 @@ usage:
     build:
       executor:
         name: go/default
-        tag: "1.14"
+        tag: "1.15"
       steps:
         - checkout
         - go/load-cache
@@ -23,4 +23,4 @@ usage:
         - go/test:
             race: true
             failfast: true
-            covermode: "atomic"  # The preferred setting when enabling race
+            covermode: "atomic" # The preferred setting when enabling race


### PR DESCRIPTION
Update Docker container `1.1.5` from [cimg/go](https://github.com/CircleCI-Public/cimg-go)