### PR TITLE
[semver:minor] Revise Go installation.

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -31,8 +31,8 @@ steps:
   - run:
       name: "Install Go"
       command: |
-        if which go;then
-          if go version | grep "<< parameters.version >>";then
+        if command -v go &>/dev/null;then
+          if go version | grep -q -F "go<< parameters.version >> ";then
             echo "Binary already exists, skipping download."
             exit 0
           else

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -31,26 +31,29 @@ steps:
   - run:
       name: "Install Go"
       command: |
-        if command -v go &>/dev/null;then
-          if go version | grep -q -F "go<< parameters.version >> ";then
+        : ${OSD_FAMILY:="linux"}
+        : ${HOSTTYPE:="amd64"}
+        if [ "${HOSTTYPE}" = "x86_64" ]; then HOSTTYPE="amd64"; fi
+        case "${HOSTTYPE}" in *86 ) HOSTTYPE=i386 ;; esac
+
+        if command -v go >/dev/null; then
+          if go version | grep -q -F "go<< parameters.version >> "; then
             echo "Binary already exists, skipping download."
             exit 0
-          else
-            echo "Go is already install but is the wrong version."
-            echo "Installing the request version instead."
           fi
 
-          echo "Installing the requested version of Go."
+          echo "Found a different version of Go."
+          OSD_FAMILY="$(go env GOHOSTOS)"
+          HOSTTYPE="$(go env GOHOSTARCH)"
+
+          $SUDO rm -rf /usr/local/go
+          $SUDO install --owner=${USER} -d /usr/local/go
         fi
 
-        if [[ $OSD_FAMILY == "linux" ]];then
-          curl -sSL "https://dl.google.com/go/go<< parameters.version >>.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/
-        elif [[ $OSD_FAMILY == "darwin" ]];then
-          curl -sSL "https://dl.google.com/go/go<< parameters.version >>.darwin-amd64.tar.gz" | sudo tar -xz -C /usr/local/
-        else
-          echo "OS/platform not supported."
-          exit 1
-        fi
+        echo "Installing the requested version of Go."
+
+        curl --fail --location -sS "https://dl.google.com/go/go<< parameters.version >>.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" \
+        | sudo tar --no-same-owner --strip-components=1 --gunzip -x -C /usr/local/go/
 
         echo "export PATH=$PATH:/usr/local/go/bin" >> $BASH_ENV
         $SUDO chown -R $(whoami): /usr/local/go


### PR DESCRIPTION
Fixes retaining stray files from previous installations.

Implements a proper version checking, and opens up the orb to different OS/architecture combinations.

[tag:Hacktoberfest] [tag:Orbtoberfest]