### PR TITLE
test: add coverpkg flag [semver:minor]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 orb.yml
+.idea

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -39,13 +39,19 @@ parameters:
       flag to set the coverage mode
       (the go default is: "set", unless -race is enabled, in which case the go default is "atomic")
     type: enum
-    enum: ["set", "count", "atomic"]
+    enum: [ "set", "count", "atomic" ]
     default: "set"
   verbose:
     description: log all tests as they are run. Also print all text from Log and Logf calls even if the test succeeds.
     type: boolean
     # Switch this to true in a major release
     default: false
+  coverpkg:
+    description: |
+      Apply coverage analysis in each test to packages matching the patterns.
+      (Sets -cover.)
+    type: string
+    default: "./..."
 steps:
   - run:
       command: >-
@@ -59,4 +65,5 @@ steps:
         -covermode=<<parameters.covermode>>
         <<# parameters.verbose >>-v<</ parameters.verbose >>
         <<parameters.packages>>
+        -coverpkg=<<parameters.coverpkg>>
       name: "go test"


### PR DESCRIPTION
This flag allows for testing with coverage for not only packages themselves but also their dependencies.

Adding this as a result of when using the orb as is, coverage would drop in unit tests when specifying specific packages.