### PR TITLE
Add compiling to tests [semver:skip]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ jobs:
       - go/load-cache:
           key: "integration"
       - go/mod-download
+      - run: go version && go build ./...
       - go/save-cache:
           key: "integration"
   int-test-cimg-base:
@@ -92,6 +93,7 @@ jobs:
       - go/load-cache:
           key: "integration"
       - go/mod-download
+      - run: go version && go build ./...
       - go/save-cache:
           key: "integration"
   int-test-macos-executor:
@@ -105,5 +107,6 @@ jobs:
       - go/load-cache:
           key: "integration"
       - go/mod-download
+      - run: go version && go build ./...
       - go/save-cache:
           key: "integration"


### PR DESCRIPTION
This runs `go build` in the tests so we can actually try compiling the
demo project that is cloned. There's a bug I'm working on fixing and it
is shown when you actually try compiling. Downloading modules and go
version isn't enough to trigger it, which makes sense.