### PR TITLE
Fix path expansion

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -56,7 +56,7 @@ steps:
         curl --fail --location -sS "https://dl.google.com/go/go<< parameters.version >>.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" \
         | sudo tar --no-same-owner --strip-components=1 --gunzip -x -C /usr/local/go/
 
-        echo "export PATH=$PATH:/usr/local/go/bin" >> $BASH_ENV
+        echo 'export PATH=$PATH:/usr/local/go/bin' >> $BASH_ENV
         $SUDO chown -R $(whoami): /usr/local/go
   - run:
       name: "Verify Go Installation"


### PR DESCRIPTION
When using this orb with pyenv, install command made the shell expand PATH environment and pyenv broke.

This is a similar issue reported in CircleCI https://discuss.circleci.com/t/failed-to-run-python-script-directly-pyenv-version-name-command-not-found/37526
and this is a brief explanation of this issue https://github.com/CircleCI-Public/gcp-cli-orb/issues/22#issuecomment-715463423.

I tested on the broken server, fixing the quote, and I confirmed it makes pyenv work appropriately.
