### PR TITLE
[semver:minor] Add mod-private command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,3 +148,18 @@ jobs:
       - go/install:
           version: 1.16.4
       - run: go version && go build ./...
+  int-test-mod-private-https:
+    environment:
+      GITHUB_PRIVATE_TOKEN: personal-access-token
+    executor:
+      name: go/default
+      tag: "1.17"
+    steps:
+      - run:
+          name: "Check out sample project"
+          command: git clone https://github.com/CircleCI-Public/circleci-demo-go.git ~/project
+      - go/mod-private:
+          basic-auth-secret: GITHUB_PRIVATE_TOKEN
+          path: github.com/circleci
+      - go/mod-download-cached
+      - run: go env GOPRIVATE && git config --get url."https://oauth2:personal-access-token@github.com/circleci"

--- a/src/commands/mod-private.yml
+++ b/src/commands/mod-private.yml
@@ -1,0 +1,35 @@
+description: Configure executor to authorize private module downloads.
+parameters:
+  basic-auth-id:
+    default: oauth2
+    description: The basic authentication identifier.
+    type: string
+  basic-auth-secret:
+    default: BASIC_AUTH_SECRET
+    description: The environment variable storing the basic authentication secret.
+    type: env_var_name
+  path:
+    description: The private module path.
+    type: string
+  protocol:
+    default: https
+    description: The protocol to use to perform Git operations.
+    enum:
+      - https
+    type: enum
+steps:
+  - when:
+      condition:
+        equal: [ << parameters.protocol >>, "https" ]
+      steps:
+        - run:
+            name: Configure Git authentication
+            command: |
+              git config --global \
+                url."https://<< parameters.basic-auth-id >>:<< parameters.basic-auth-secret >>@<< parameters.path >>".insteadOf \
+                "https://<< parameters.path >>"
+  - run:
+      name: Configure GOPRIVATE Go env var
+      command: |
+        GOPRIVATE="$(go env GOPRIVATE)"
+        go env -w GOPRIVATE="${GOPRIVATE:+$GOPRIVATE,}<< parameters.path >>"

--- a/src/examples/mod-private.yml
+++ b/src/examples/mod-private.yml
@@ -1,0 +1,23 @@
+description: "Configure environment to download private Go modules"
+
+usage:
+  version: 2.1
+
+  orbs:
+    go: circleci/go@x.y
+
+  workflows:
+    main:
+      jobs:
+        - build
+  jobs:
+    build:
+      executor:
+        name: go/default
+        tag: "1.16"
+      steps:
+        - checkout
+        - go/mod-private:
+            basic-auth-secret: GITHUB_PRIVATE_TOKEN
+            path: "github.com/circleci"
+        - go/mod-download-cached


### PR DESCRIPTION
I am proposing the addition of the `mod-private` command that set up both `git` and `go` appropriately to download private modules.

The command sets for the provided module path:
- the basic auth to use for `git` operations using `https` protocol (the command can be further enhanced to support `ssh`)
- `GOPRIVATE` `go` environment variable to bypass `GOPROXY` and `GOSUMDB`

It is safe to invoke the command multiple times consecutively for different module paths.