### PR TITLE
chore: Remove extraneous quotes

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,6 +1,6 @@
 description: |
-  "The official CircleCI Go Docker image on Docker Hub.
-  Found here: https://hub.docker.com/r/cimg/go"
+  The official CircleCI Go Docker image on Docker Hub.
+  Found here: https://hub.docker.com/r/cimg/go
 parameters:
   tag:
     description: "The `cimg/go` Docker image version tag."


### PR DESCRIPTION
With the block YAML string indicator, the quotes are unnecessary in defining the description for the default executor.

<img width="368" alt="image" src="https://user-images.githubusercontent.com/33203301/197886011-b6e9d15c-b83a-4f81-9539-6ea77b1179d5.png">

This PR just removes the extraneous quotes.