### PR TITLE
bug fix for missing sudo

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -22,7 +22,7 @@ fi
 echo "Installing the requested version of Go."
 
 curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" \
-| sudo tar --no-same-owner --strip-components=1 --gunzip -x -C /usr/local/go/
+| $SUDO tar --no-same-owner --strip-components=1 --gunzip -x -C /usr/local/go/
 
 echo "export PATH=$PATH:/usr/local/go/bin" >> "$BASH_ENV"
 $SUDO chown -R "$(whoami)": /usr/local/go


### PR DESCRIPTION
Fix for missing sudo. It seems `$SUDO` was missing in one place.

```
Installing the requested version of Go.
/bin/bash: line 22: sudo: command not found
curl: (23) Failed writing body (1349 != 1378)

Exited with code exit status 127
```