### PR TITLE
Update default Go version

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -4,7 +4,7 @@ parameters:
   version:
     description: "The Go version."
     type: string
-    default: "1.16.5"
+    default: "1.18.10"
   cache:
     description: Whether or not to cache the binary.
     type: boolean


### PR DESCRIPTION
Update from `1.16.5` (released in Feb 2021) as the default version to something more recent like 1.18.10