### PR TITLE
fix set: -c: invalid option

### DIFF
--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -2,19 +2,19 @@
 COVER_PROFILE=$(eval echo "$ORB_EVAL_COVER_PROFILE")
 
 if [ -n "$ORB_VAL_RACE" ]; then
-  set "$@" -- -race
+  set -- "$@" -race
 fi
 
 if [ -n "$ORB_VAL_FAIL_FAST" ]; then
-  set "$@" -- -failfast
+  set -- "$@" -failfast
 fi
 
 if [ -n "$ORB_VAL_SHORT" ]; then
-  set "$@" -- -short
+  set -- "$@" -short
 fi
 
 if [ -n "$ORB_VAL_VERBOSE" ]; then
-  set "$@" -- -v
+  set -- "$@" -v
 fi
 
 set -x


### PR DESCRIPTION
Looks like f9704db51eba477f27d22bb344266f2d5f695ac8 was accidentally reverted, and it causes the error reported in #69:

```
/bin/bash: line 9: set: -c: invalid option
set: usage: set [-abefhkmnptuvxBCHP] [-o option-name] [--] [arg ...]
```

This PR fixes this error.