### PR TITLE
feat: add goreleaser-release command 

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -11,8 +11,16 @@ jobs:
       name: go/default
       tag: "1.20.8"
     steps:
-      - checkout
       - go/install-goreleaser
+  int-test-goreleaser-release:
+    executor:
+      name: go/default
+      tag: "1.20.8"
+    steps:
+      - go/install-goreleaser
+      - go/goreleaser-release:
+          validate-yaml: true
+          publish-release: false
   int-test-cimg-go:
     executor:
       name: go/default
@@ -120,6 +128,8 @@ workflows:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
       - int-test-goreleaser-install:
           filters: *filters
+      - int-test-goreleaser-release:
+          filters: *filters
       - int-test-cimg-go:
           filters: *filters
       - int-test-cimg-base:
@@ -150,6 +160,7 @@ workflows:
             - int-test-dirty-cache
             - int-test-vm-arm64
             - int-test-goreleaser-install
+            - int-test-goreleaser-release
           context: orb-publisher
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -19,8 +19,10 @@ jobs:
     steps:
       - go/install-goreleaser
       - go/goreleaser-release:
+          github-token: TEST_GH_TOKEN
           validate-yaml: true
           publish-release: false
+          project-path: ~/project/tests
   int-test-cimg-go:
     executor:
       name: go/default
@@ -129,6 +131,11 @@ workflows:
       - int-test-goreleaser-install:
           filters: *filters
       - int-test-goreleaser-release:
+          pre-steps:
+            - checkout
+            - run:
+                name: Change to test directory
+                command: cd ~/project/tests
           filters: *filters
       - int-test-cimg-go:
           filters: *filters

--- a/src/commands/goreleaser-release.yml
+++ b/src/commands/goreleaser-release.yml
@@ -1,0 +1,29 @@
+description: |
+  Build Go applications and release them on GitHub. 
+  GoReleaser CLI must be installed and a GitHub Token
+  with write:packages permissions is also required.
+
+parameters:
+  github-token:
+    description: |
+      A GitHub Token is with write:packages permissions is required.
+    type: string
+    default: GITHUB_TOKEN
+  validate-yaml:
+    description: |
+      Set to true to validate .goreleaser.yaml.
+    type: boolean
+    default: false
+  publish-release:
+    description: |
+      Set to true to publish release to GitHub
+    type: boolean
+    default: false
+steps:
+  - run:
+      name: "Build and release Go Binaries to GitHub with GoReleaser"
+      environment:
+        GITHUB_TOKEN: << parameters.github-token >>
+        GO_BOOL_VALIDATE_YAML: << parameters.validate-yaml >>
+        GO_BOOL_PUBLISH_RELEASE: << parameters.publish-release >>
+      command: << include(scripts/goreleaser-release.sh) >>

--- a/src/commands/goreleaser-release.yml
+++ b/src/commands/goreleaser-release.yml
@@ -1,5 +1,5 @@
 description: |
-  Build Go applications and release them on GitHub. 
+  Build Go applications and release them on GitHub.
   GoReleaser CLI must be installed and a GitHub Token
   with write:packages permissions is also required.
 
@@ -9,6 +9,13 @@ parameters:
       A GitHub Token is with write:packages permissions is required.
     type: string
     default: GITHUB_TOKEN
+  project-path:
+    description: |
+      The path to the directory containing your Go project files:
+      .goreleaser.yaml, go.mod, main.go.
+      Defaults to $HOME.
+    type: string
+    default: $HOME
   validate-yaml:
     description: |
       Set to true to validate .goreleaser.yaml.
@@ -26,4 +33,5 @@ steps:
         GITHUB_TOKEN: << parameters.github-token >>
         GO_BOOL_VALIDATE_YAML: << parameters.validate-yaml >>
         GO_BOOL_PUBLISH_RELEASE: << parameters.publish-release >>
+        GO_EVAL_PROJECT_PATH: << parameters.project-path >>
       command: << include(scripts/goreleaser-release.sh) >>

--- a/src/commands/install-goreleaser.yml
+++ b/src/commands/install-goreleaser.yml
@@ -1,11 +1,10 @@
 description: |
   GoReleaser is a release automation tool for managing Go projects.
   Install GoReleaser in your build. Golang must be installed.
-  A GitHub Token is with write:packages permissions is also required.
 
 parameters:
   version:
-    description: The GoRelaser version to install. Defaults to latest
+    description: The GoReleaser version to install. Defaults to latest
     type: string
     default: "latest"
 

--- a/src/examples/goreleaser-release.yml
+++ b/src/examples/goreleaser-release.yml
@@ -14,7 +14,7 @@ usage:
       steps:
         - go/install-goreleaser
         - go/goreleaser-release:
-            # validate .goreleaser.yml 
+            # validate .goreleaser.yml
             validate-yaml: true
             # publish release on GitHub
             publish-release: true

--- a/src/examples/goreleaser-release.yml
+++ b/src/examples/goreleaser-release.yml
@@ -1,0 +1,25 @@
+description: |
+  Build Go applications and release them on GitHub.
+  Install GoReleaser CLI and add a GitHub Token with
+  write:packages permissions and store as environment variable.
+usage:
+  version: 2.1
+  orbs:
+    go: circleci/go@x.y
+  jobs:
+    go-build-release:
+      executor:
+        name: go/default
+        tag: "1.20.8"
+      steps:
+        - go/install-goreleaser
+        - go/goreleaser-release:
+            # validate .goreleaser.yml 
+            validate-yaml: true
+            # publish release on GitHub
+            publish-release: true
+            project-path: /path/to/Go/project
+  workflows:
+    main:
+      jobs:
+        - go-build-release

--- a/src/scripts/goreleaser-release.sh
+++ b/src/scripts/goreleaser-release.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
-GITHUB_TOKEN="$(echo "\$$GITHUB_TOKEN" | circleci env subst)"
 
-if [ -n "${GITHUB_TOKEN}" ]; then
+GITHUB_TOKEN="$(echo "\$$GITHUB_TOKEN" | circleci env subst)"
+GO_EVAL_PROJECT_PATH="$(eval echo "${GO_EVAL_PROJECT_PATH}")"
+
+# Change to directory containing project files
+cd "${GO_EVAL_PROJECT_PATH}" || return
+
+if [ -z "${GITHUB_TOKEN}" ]; then
     echo "No GitHub Token provided. Please add token as environment variable in CircleCI."
+    exit 1
 fi
 
 if [ "$GO_BOOL_VALIDATE_YAML" -eq 1 ]; then 
@@ -17,4 +23,5 @@ else
     # Build binaries and test release locally
     goreleaser release --snapshot --clean
 fi
+
 

--- a/src/scripts/goreleaser-release.sh
+++ b/src/scripts/goreleaser-release.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+GITHUB_TOKEN="$(echo "\$$GITHUB_TOKEN" | circleci env subst)"
+
+if [ -n "${GITHUB_TOKEN}" ]; then
+    echo "No GitHub Token provided. Please add token as environment variable in CircleCI."
+fi
+
+if [ "$GO_BOOL_VALIDATE_YAML" -eq 1 ]; then 
+    # Validate .goreleaser.yaml file
+    goreleaser check
+fi
+
+if [ "$GO_BOOL_PUBLISH_RELEASE" -eq 1 ]; then 
+    # Build binaries and publish release to GitHub
+    goreleaser release 
+else
+    # Build binaries and test release locally
+    goreleaser release --snapshot --clean
+fi
+

--- a/tests/.goreleaser.yaml
+++ b/tests/.goreleaser.yaml
@@ -1,0 +1,44 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines bellow are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,0 +1,3 @@
+module main
+
+go 1.20

--- a/tests/main.go
+++ b/tests/main.go
@@ -1,0 +1,6 @@
+// main.go
+package main
+
+func main() {
+  println("Hello, World!")
+}


### PR DESCRIPTION
This pull request adds the goreleaser-release command, enabling users to build go binaries and release them to GitHub. 