### PR TITLE
implement timeout flags

### DIFF
--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -23,6 +23,10 @@ parameters:
     description: tell long-running tests to shorten their run time
     type: boolean
     default: false
+  timeout:
+    description: timeout the test and panic after value - for situations where a test has a valid usecase to go longer than 10m
+    type: string
+    default: "10m"
   parallel:
     description: |
       Allow parallel execution of test functions that call t.Parallel.
@@ -59,6 +63,7 @@ steps:
         ORB_VAL_COUNT: <<parameters.count>>
         ORB_VAL_FAIL_FAST: <<parameters.failfast>>
         ORB_VAL_SHORT: <<parameters.short>>
+        ORB_VAL_TIMEOUT: <<parameters.timeout>>
         ORB_VAL_PARALLEL: <<parameters.parallel>>
         ORB_VAL_COVER_MODE: <<parameters.covermode>>
         ORB_VAL_VERBOSE: <<parameters.verbose>>

--- a/src/examples/test.yml
+++ b/src/examples/test.yml
@@ -24,3 +24,4 @@ usage:
             race: true
             failfast: true
             covermode: "atomic" # The preferred setting when enabling race
+            timeout: "15m" # In cases where a test has a valid usecase to go longer than the default 10m

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -21,5 +21,6 @@ set -x
 go test -count="$ORB_VAL_COUNT" -coverprofile="$COVER_PROFILE" \
     -p "$ORB_VAL_PARALLEL" -covermode="$ORB_VAL_COVER_MODE" \
     "$ORB_VAL_PACKAGES" -coverpkg="$ORB_VAL_PACKAGES" \
+    -timeout="$ORB_VAL_TIMEOUT" \
     "$@"
 set +x


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

We've run into an issue in a large GCP infrastructure where amending (or in certain cases deploying) things like GKE clusters, the process can take upwards of 10m and this can be reflected in tests. We'd like to be able to set that time as per [go docs](https://pkg.go.dev/cmd/go/internal/test)

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Added the flag and support for it