### PR TITLE
feat: implement go based timeout for the test command

### DIFF
--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -23,6 +23,10 @@ parameters:
     description: tell long-running tests to shorten their run time
     type: boolean
     default: false
+  timeout:
+    description: timeout the test and panic after value - for situations where a test has a valid usecase to go longer than 10m
+    type: string
+    default: "10m"
   parallel:
     description: |
       Allow parallel execution of test functions that call t.Parallel.
@@ -63,6 +67,7 @@ steps:
         ORB_VAL_COUNT: <<parameters.count>>
         ORB_VAL_FAIL_FAST: <<parameters.failfast>>
         ORB_VAL_SHORT: <<parameters.short>>
+        ORB_VAL_TIMEOUT: <<parameters.timeout>>
         ORB_VAL_PARALLEL: <<parameters.parallel>>
         ORB_VAL_COVER_MODE: <<parameters.covermode>>
         ORB_VAL_VERBOSE: <<parameters.verbose>>

--- a/src/examples/test.yml
+++ b/src/examples/test.yml
@@ -26,5 +26,3 @@ usage:
             covermode: "atomic" # The preferred setting when enabling race
             timeout: 15m #The amount of time to allow the go tests to run before timing out, defaults to "10m"
             no_output_timeout: 15m # The amount of time to allow the orb to run without output before timing out, defaults to "10m"
-
-            

--- a/src/examples/test.yml
+++ b/src/examples/test.yml
@@ -24,4 +24,7 @@ usage:
             race: true
             failfast: true
             covermode: "atomic" # The preferred setting when enabling race
-            no_output_timeout: 15m # The amount of time to allow the go tests to run before timing out, defaults to "10m"
+            timeout: 15m #The amount of time to allow the go tests to run before timing out, defaults to "10m"
+            no_output_timeout: 15m # The amount of time to allow the orb to run without output before timing out, defaults to "10m"
+
+            

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -21,5 +21,6 @@ set -x
 go test -count="$ORB_VAL_COUNT" -coverprofile="$COVER_PROFILE" \
     -p "$ORB_VAL_PARALLEL" -covermode="$ORB_VAL_COVER_MODE" \
     "$ORB_VAL_PACKAGES" -coverpkg="$ORB_VAL_PACKAGES" \
+    -timeout="$ORB_VAL_TIMEOUT" \
     "$@"
 set +x


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Previous PR: https://github.com/CircleCI-Public/go-orb/pull/80

On further investigation, we did notice that local tests pass (note the 10m9s, as well as additional resources being created):

```
TestModule 2024-01-19T18:30:47-05:00 logger.go:66: module.test.google_container_cluster.flex_cluster: Creation complete after 10m9s [id=projects/unit-test-dev-rotw-4a49/locations/us-east1/clusters/int-test-flex-dev-rotw]
TestModule 2024-01-19T18:30:47-05:00 logger.go:66: module.test.module.default_node_pool.google_container_node_pool.node_pool: Creating...
TestModule 2024-01-19T18:30:57-05:00 logger.go:66: module.test.module.default_node_pool.google_container_node_pool.node_pool: Still creating... [10s elapsed]
TestModule 2024-01-19T18:31:07-05:00 logger.go:66: module.test.module.default_node_pool.google_container_node_pool.node_pool: Still creating... [20s elapsed]
TestModule 2024-01-19T18:31:17-05:00 logger.go:66: module.test.module.default_node_pool.google_container_node_pool.node_pool: Still creating... [30s elapsed]
TestModule 2024-01-19T18:31:27-05:00 logger.go:66: module.test.module.default_node_pool.google_container_node_pool.node_pool: Still creating... [40s elapsed]
TestModule 2024-01-19T18:31:37-05:00 logger.go:66: module.test.module.default_node_pool.google_container_node_pool.node_pool: Still creating... [50s elapsed]
TestModule 2024-01-19T18:31:47-05:00 logger.go:66: module.test.module.default_node_pool.google_container_node_pool.node_pool: Still creating... [1m0s elapsed]
TestModule 2024-01-19T18:31:57-05:00 logger.go:66: module.test.module.default_node_pool.google_container_node_pool.node_pool: Still creating... [1m10s elapsed]
TestModule 2024-01-19T18:32:07-05:00 logger.go:66: module.test.module.default_node_pool.google_container_node_pool.node_pool: Still creating... [1m20s elapsed]
TestModule 2024-01-19T18:32:17-05:00 logger.go:66: module.test.module.default_node_pool.google_container_node_pool.node_pool: Still creating... [1m30s elapsed]
TestModule 2024-01-19T18:32:19-05:00 logger.go:66: module.test.module.default_node_pool.google_container_node_pool.node_pool: Creation complete after 1m33s [id=projects/unit-test-dev-rotw-4a49/locations/us-east1/clusters/int-test-flex-dev-rotw/nodePools/f7-df20240119233047401900000001]
TestModule 2024-01-19T18:32:19-05:00 logger.go:66:
TestModule 2024-01-19T18:32:19-05:00 logger.go:66: Apply complete! Resources: 8 added, 0 changed, 0 destroyed.
```

while CircleCI-based runs failed:

![Selection_111](https://github.com/CircleCI-Public/go-orb/assets/25034184/1db7b72c-1aab-4b22-94aa-d81a08be2983)

This was with `no_output_timeout`, implemented on @EricRibeiro's suggestion, enabled.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

This update should solve this. 