### PR TITLE
Update test.sh

### DIFF
--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -5,7 +5,7 @@ if [ -n "$ORB_VAL_RACE" ]; then
   set -- "$@" -race
 fi
 
-if [ -n "$ORB_VAL_FAIL_FAST" ]; then
+if [ "$ORB_VAL_FAILFAST" != "false" ]; then
   set -- "$@" -failfast
 fi
 


### PR DESCRIPTION
if [ -n "$ORB_VAL_FAIL_FAST" ]; then
    set -- "$@" -failfast
fi

will always equate to truthy as we set the `fastfail` param to false by default and the set  ORB_VAL_FAIL_FAST: <<parameters.failfast>>. The update should resolve the issue. 