### PR TITLE
Fixing misleading documentation on test.parallel

### DIFF
--- a/max_parallelism/main.go
+++ b/max_parallelism/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func MaxParallelism() int {
+	maxProcs := runtime.GOMAXPROCS(0)
+	numCPU := runtime.NumCPU()
+	if maxProcs < numCPU {
+		return maxProcs
+	}
+	return numCPU
+}
+
+func main() {
+	fmt.Println(MaxParallelism())
+}

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -29,11 +29,18 @@ parameters:
     default: "10m"
   parallel:
     description: |
+      The number of programs, such as build commands or
+      test binaries, that can be run in parallel.
+      The default is GOMAXPROCS, normally the number of CPUs available.
+    type: string
+    default: "m"
+  parallel-tests:
       Allow parallel execution of test functions that call t.Parallel.
       The value of this flag is the maximum number of tests to run
-      simultaneously
+      simultaneously.
+      By default, -parallel is set to the value of GOMAXPROCS.
     type: string
-    default: "1"
+    default: "m"
   coverprofile:
     description: file to save coverage profile
     type: string
@@ -76,6 +83,7 @@ steps:
         ORB_VAL_SHORT: <<parameters.short>>
         ORB_VAL_TIMEOUT: <<parameters.timeout>>
         ORB_VAL_PARALLEL: <<parameters.parallel>>
+        ORB_VAL_PARALLEL_TESTS: <<parameters.parallel-tests>>
         ORB_VAL_COVER_MODE: <<parameters.covermode>>
         ORB_VAL_VERBOSE: <<parameters.verbose>>
         ORB_VAL_PACKAGES: <<parameters.packages>>

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -35,6 +35,7 @@ parameters:
     type: string
     default: "m"
   parallel-tests:
+    description: |
       Allow parallel execution of test functions that call t.Parallel.
       The value of this flag is the maximum number of tests to run
       simultaneously.

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if [ "${ORB_VAL_PARALLEL}" = "m" -o "${ORB_VAL_PARALLEL_TESTS}" = "m" ]; then
+if [ "${ORB_VAL_PARALLEL}" = "m" ] || [ "${ORB_VAL_PARALLEL_TESTS}" = "m" ]; then
   GOMAXPROCS=$(go run max_parallelism/main.go)
 fi
 

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
+if [ "${ORB_VAL_PARALLEL}" = "m" -o "${ORB_VAL_PARALLEL_TESTS}" = "m" ]; then
+  GOMAXPROCS=$(go run max_parallelism/main.go)
+fi
+
+if [ "${ORB_VAL_PARALLEL}" = "m" ]; then
+  ORB_VAL_PARALLEL=$GOMAXPROCS
+fi
+
+if [ "${ORB_VAL_PARALLEL_TESTS}" = "m" ]; then
+  ORB_VAL_PARALLEL_TESTS=$GOMAXPROCS
+fi
 
 if [ -n "${ORB_EVAL_PROJECT_PATH}" ]; then
   cd "${ORB_EVAL_PROJECT_PATH}" || exit
@@ -24,8 +35,9 @@ if [ -n "$ORB_VAL_VERBOSE" ]; then
 fi
 
 set -x
-go test -count="$ORB_VAL_COUNT" -coverprofile="$COVER_PROFILE" \
-    -p "$ORB_VAL_PARALLEL" -covermode="$ORB_VAL_COVER_MODE" \
+go test -count="$ORB_VAL_COUNT" -p "${ORB_VAL_PARALLEL}" \
+    -parallel "${ORB_VAL_PARALLEL_TESTS}" \
+    -coverprofile="$COVER_PROFILE" -covermode="$ORB_VAL_COVER_MODE" \
     "$ORB_VAL_PACKAGES" -coverpkg="$ORB_VAL_PACKAGES" \
     -timeout="$ORB_VAL_TIMEOUT" \
     "$@"


### PR DESCRIPTION
Solves [issue-83](https://github.com/CircleCI-Public/go-orb/issues/83).

This PR:
- adds a new `parallel-tests` to the orb to differentiate it from the current `parallel` parameter
- adds a simple GOMAXPROCS main.go program to get the correct number to use for both `-p` and `-parallel` flags.