### PR TITLE
feat: add options to the test command

### DIFF
--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -19,6 +19,10 @@ parameters:
     description: do not start new tests after the first test failure
     type: boolean
     default: false
+  run:
+    description: A regexp matching the names of the tests and examples that will be executed.
+    type: string
+    default: ""
   short:
     description: tell long-running tests to shorten their run time
     type: boolean
@@ -75,6 +79,14 @@ parameters:
       Defaults to $HOME.
     type: string
     default: ""
+  build_tags:
+    description: A comma-separated list of additional build tags to consider satisfied during the build.
+    type: string
+    default: ""
+  build_ldflags:
+    description: Arguments to pass on each go tool link invocation.
+    type: string
+    default: ""
 steps:
   - run:
       environment:
@@ -89,6 +101,9 @@ steps:
         ORB_VAL_VERBOSE: <<parameters.verbose>>
         ORB_VAL_PACKAGES: <<parameters.packages>>
         ORB_VAL_COVERPKG: <<parameters.coverpkg>>
+        ORB_VAL_BUILD_TAGS: <<parameters.build_tags>>
+        ORB_VAL_BUILD_LDFLAGS: <<parameters.build_ldflags>>
+        ORB_VAL_RUN: <<parameters.run>>
         ORB_EVAL_COVER_PROFILE: <<parameters.coverprofile>>
         ORB_EVAL_PROJECT_PATH: <<parameters.project-path>>
       command: <<include(scripts/test.sh)>>

--- a/src/examples/test.yml
+++ b/src/examples/test.yml
@@ -23,6 +23,9 @@ usage:
               - go/test:
                   race: true
                   failfast: true
+                  run: "^TestName$"
                   covermode: "atomic" # The preferred setting when enabling race
                   timeout: 15m #The amount of time to allow the go tests to run before timing out, defaults to "10m"
                   no_output_timeout: 15m # The amount of time to allow the orb to run without output before timing out, defaults to "10m"
+                  build_tags: "integration,e2e"
+                  build_ldflags: "-X 'main.Version=v1.0.0'"

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -39,6 +39,7 @@ go test -count="$ORB_VAL_COUNT" -p "${ORB_VAL_PARALLEL}" \
     -parallel "${ORB_VAL_PARALLEL_TESTS}" \
     -coverprofile="$COVER_PROFILE" -covermode="$ORB_VAL_COVER_MODE" \
     "$ORB_VAL_PACKAGES" -coverpkg="$ORB_VAL_PACKAGES" \
-    -timeout="$ORB_VAL_TIMEOUT" \
+    -timeout="$ORB_VAL_TIMEOUT" -tags="$ORB_VAL_BUILD_TAGS" \
+    -ldflags="$ORB_VAL_BUILD_LDFLAGS" -run="$ORB_VAL_RUN" \
     "$@"
 set +x


### PR DESCRIPTION
This originally comes from the following [PR](https://github.com/CircleCI-Public/go-orb/pull/84).

Adds the following options to the test command:
- Build tags
- LDFlags
- Test name pattern matching