### PR TITLE
Revert "Implement 'project-path' for the load-cache and save-cache commands"

### DIFF
--- a/src/commands/load-build-cache.yml
+++ b/src/commands/load-build-cache.yml
@@ -4,13 +4,7 @@ parameters:
     description: "User-configurable component for cache key. Useful for avoiding collisions in complex workflows."
     type: string
     default: ""
-  project-path:
-    description: |
-      The path to the directory containing your Go project files: go.mod, go.sum.
-      Defaults to $CIRCLE_WORKING_DIRECTORY.
-    type: string
-    default: $CIRCLE_WORKING_DIRECTORY
 steps:
   - restore_cache:
       keys:
-        - v1-<< parameters.key >>-go-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "<< parameters.project-path >>/go.sum" }}-{{ epoch | round "72h" }}
+        - v1-<< parameters.key >>-go-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "go.sum" }}-{{ epoch | round "72h" }}

--- a/src/commands/load-golangci-lint-cache.yml
+++ b/src/commands/load-golangci-lint-cache.yml
@@ -4,13 +4,7 @@ parameters:
     description: "User-configurable component for cache key. Useful for avoiding collisions in complex workflows."
     type: string
     default: ""
-  project-path:
-    description: |
-      The path to the directory containing your Go project files: go.mod, go.sum.
-      Defaults to $CIRCLE_WORKING_DIRECTORY.
-    type: string
-    default: $CIRCLE_WORKING_DIRECTORY
 steps:
   - restore_cache:
       keys:
-        - v1-<< parameters.key >>-golangci-lint-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "<< parameters.project-path >>/go.sum" }}-{{ epoch | round "72h" }}
+        - v1-<< parameters.key >>-golangci-lint-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "go.sum" }}-{{ epoch | round "72h" }}

--- a/src/commands/load-mod-cache.yml
+++ b/src/commands/load-mod-cache.yml
@@ -4,13 +4,7 @@ parameters:
     description: "User-configurable component for cache key. Useful for avoiding collisions in complex workflows."
     type: string
     default: ""
-  project-path:
-    description: |
-      The path to the directory containing your Go project files: go.mod, go.sum.
-      Defaults to $CIRCLE_WORKING_DIRECTORY.
-    type: string
-    default: $CIRCLE_WORKING_DIRECTORY
 steps:
   - restore_cache:
       keys:
-        - v1-<< parameters.key >>-go-mod-{{ arch }}-{{ checksum "<< parameters.project-path >>/go.sum" }}
+        - v1-<< parameters.key >>-go-mod-{{ arch }}-{{ checksum "go.sum" }}

--- a/src/commands/save-build-cache.yml
+++ b/src/commands/save-build-cache.yml
@@ -8,14 +8,8 @@ parameters:
     description: "Path to cache."
     type: string
     default: "/home/circleci/.cache/go-build"
-  project-path:
-    description: |
-      The path to the directory containing your Go project files: go.mod, go.sum.
-      Defaults to $CIRCLE_WORKING_DIRECTORY.
-    type: string
-    default: $CIRCLE_WORKING_DIRECTORY
 steps:
   - save_cache:
-      key: v1-<< parameters.key >>-go-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "<< parameters.project-path >>/go.sum" }}-{{ epoch | round "72h" }}
+      key: v1-<< parameters.key >>-go-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "go.sum" }}-{{ epoch | round "72h" }}
       paths:
         - << parameters.path >>

--- a/src/commands/save-golangci-lint-cache.yml
+++ b/src/commands/save-golangci-lint-cache.yml
@@ -8,14 +8,9 @@ parameters:
     description: "Path to cache."
     type: string
     default: "/home/circleci/.cache/golangci-lint"
-  project-path:
-    description: |
-      The path to the directory containing your Go project files: go.mod, go.sum.
-      Defaults to $CIRCLE_WORKING_DIRECTORY.
-    type: string
-    default: $CIRCLE_WORKING_DIRECTORY
 steps:
   - save_cache:
-      key: v1-<< parameters.key >>-golangci-lint-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "<< parameters.project-path >>/go.sum" }}-{{ epoch | round "72h" }}
+      key: v1-<< parameters.key >>-golangci-lint-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "go.sum" }}-{{ epoch | round "72h" }}
       paths:
         - << parameters.path >>
+

--- a/src/commands/save-mod-cache.yml
+++ b/src/commands/save-mod-cache.yml
@@ -9,14 +9,8 @@ parameters:
     type: string
     # /home/circleci/go is the GOPATH in the cimg/go Docker image
     default: "/home/circleci/go/pkg/mod"
-  project-path:
-    description: |
-      The path to the directory containing your Go project files: go.mod, go.sum.
-      Defaults to $CIRCLE_WORKING_DIRECTORY.
-    type: string
-    default: $CIRCLE_WORKING_DIRECTORY
 steps:
   - save_cache:
-      key: v1-<< parameters.key >>-go-mod-{{ arch }}-{{ checksum "<< parameters.project-path >>/go.sum" }}
+      key: v1-<< parameters.key >>-go-mod-{{ arch }}-{{ checksum "go.sum" }}
       paths:
         - << parameters.path >>


### PR DESCRIPTION
Reverts CircleCI-Public/go-orb#85 - the defaults are wrong, you cant refer to an env var in here