### PR TITLE
Adding support to install different go versions in Alpine

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -145,7 +145,7 @@ jobs:
       - go/save-mod-cache:
           key: "integration"
       - go/install:
-          version: 1.16.4
+          version: 1.23.3
       - run: go version && go build ./...
   go-test-default:
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -145,7 +145,7 @@ jobs:
       - go/save-mod-cache:
           key: "integration"
       - go/install:
-          version: 1.23.3
+          version: 1.16.1
       - run: go version && go build ./...
   go-test-default:
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -70,6 +70,15 @@ jobs:
       - run:
           name: "Check if the correct python version is accessible & installed"
           command: python --version | grep -q "^Python 3.11"
+  int-test-alpine:
+    docker:
+      - image: alpine:latest
+    steps:
+      - go/install:
+          version: 1.17.2
+      - run:
+          name: "Check if the correct python version is accessible & installed"
+          command: python --version | grep -q "^Python 3.11"
   int-test-macos-executor:
     macos:
       xcode: "14.1.0"
@@ -192,6 +201,8 @@ workflows:
           filters: *filters
       - int-test-cimg-python:
           filters: *filters
+      - int-test-alpine:
+          filters: *filters
       - int-test-macos-executor:
           filters: *filters
       - int-test-vm-linux:
@@ -220,6 +231,7 @@ workflows:
             - int-test-cimg-go
             - int-test-cimg-base
             - int-test-cimg-python
+            - int-test-alpine
             - int-test-macos-executor
             - int-test-vm-linux
             - int-test-dirty-cache

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -145,7 +145,7 @@ jobs:
       - go/save-mod-cache:
           key: "integration"
       - go/install:
-          version: 1.16.1
+          version: 1.15.1
       - run: go version && go build ./...
   go-test-default:
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -78,8 +78,8 @@ jobs:
       - go/install:
           version: 1.17.2
       - run:
-          name: "Check if the correct python version is accessible & installed"
-          command: python --version | grep -q "^Python 3.11"
+          name: "Check if the correct go version is accessible & installed"
+          command: go version | grep -q "1.17.2"
   int-test-macos-executor:
     macos:
       xcode: "14.1.0"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -74,6 +74,7 @@ jobs:
     docker:
       - image: alpine:latest
     steps:
+      - run: apk add curl
       - go/install:
           version: 1.17.2
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -145,7 +145,7 @@ jobs:
       - go/save-mod-cache:
           key: "integration"
       - go/install:
-          version: 1.15.1
+          version: 1.16.4
       - run: go version && go build ./...
   go-test-default:
     docker:

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -21,14 +21,14 @@ if command -v go >/dev/null; then
 fi
 
 # Checking if Alpine is being used to update the tar options
-TAR_OPTIONS="--no-same-owner --strip-components=1 --gunzip -x -C"
+TAR_OPTIONS=(--no-same-owner --strip-components)1 --gunzip -x -C)
 if [[ $(grep '^NAME=' /etc/os-release | cut -d'=' -f2) = "Alpine Linux" ]]; then
-  TAR_OPTIONS="-o --strip-components=1 -z -x -C"
+  TAR_OPTIONS=(-o --strip-components=1 -z -x -C)
 fi
 
 echo "Installing the requested version of Go."
 curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" |
-  $SUDO tar ${TAR_OPTIONS} /usr/local/go/
+  $SUDO tar "${TAR_OPTIONS[@]}" /usr/local/go/
 
 #shellcheck disable=SC2016
 echo 'export PATH=$PATH:/usr/local/go/bin' >>"$BASH_ENV"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -22,8 +22,7 @@ fi
 
 # Checking if Alpine is being used to update the tar options
 echo "Installing the requested version of Go."
-grep 'Alpine Linux' /etc/os-release
-if [ "$?" ]; then
+if grep -q 'Alpine Linux' /etc/os-release; then
   curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" |
     $SUDO tar -o --strip-components=1 -z -x -C /usr/local/go/
 else

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -22,7 +22,8 @@ fi
 
 # Checking if Alpine is being used to update the tar options
 echo "Installing the requested version of Go."
-if [ "$(grep -q 'Alpine Linux' /etc/os-release)" ]; then
+grep 'Alpine Linux' /etc/os-release
+if [ "$?" ]; then
   curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" |
     $SUDO tar -o --strip-components=1 -z -x -C /usr/local/go/
 else

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -21,14 +21,14 @@ if command -v go >/dev/null; then
 fi
 
 # Checking if Alpine is being used to update the tar options
-TAR_OPTIONS=(--no-same-owner --strip-components=1 --gunzip -x -C)
-if [[ $(grep '^NAME=' /etc/os-release | cut -d'=' -f2) = "Alpine Linux" ]]; then
-  TAR_OPTIONS=(-o --strip-components=1 -z -x -C)
-fi
-
 echo "Installing the requested version of Go."
-curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" |
-  $SUDO tar "${TAR_OPTIONS[@]}" /usr/local/go/
+if [[ $(grep '^NAME=' /etc/os-release | cut -d'=' -f2) = "Alpine Linux" ]]; then
+  curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" |
+    $SUDO tar -o --strip-components=1 -z -x -C /usr/local/go/
+else
+  curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" |
+    $SUDO tar --no-same-owner --strip-components=1 --gunzip -x -C /usr/local/go/
+fi
 
 #shellcheck disable=SC2016
 echo 'export PATH=$PATH:/usr/local/go/bin' >>"$BASH_ENV"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,32 +1,53 @@
 #!/usr/bin/env bash
 
+function alpine_install {
+  cd /opt
+  apk add bash gcc musl-dev go
+  wget https://go.dev/dl/go${ORB_VAL_VERSION}.src.tar.gz
+  tar xzf go${ORB_VAL_VERSION}.src.tar.gz
+  mv go go${ORB_VAL_VERSION}
+  cd go${ORB_VAL_VERSION}/src
+  ./make.bash
+  apk del go
+  ln -s /opt/go${ORB_VAL_VERSION}/bin/go /usr/local/bin/go
+  ln -s /opt/go${ORB_VAL_VERSION}/bin/gofmt /usr/local/bin/gofmt
+}
+
+function standard_install {
+  if command -v go >/dev/null; then
+    if go version | grep -q -F "go<< parameters.version >> "; then
+      echo "Binary already exists, skipping download."
+      exit 0
+    fi
+
+    echo "Found a different version of Go."
+    OSD_FAMILY="$(go env GOHOSTOS)"
+    HOSTTYPE="$(go env GOHOSTARCH)"
+
+    $SUDO rm -rf /usr/local/go
+    $SUDO install --owner="${USER}" -d /usr/local/go
+  fi
+
+  echo "Installing the requested version of Go."
+  curl -O --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
+  $SUDO tar xzf "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" -C /opt
+  rm "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
+  ln -s /opt/go/bin/go /usr/local/bin/go
+  ln -s /opt/go/bin/gofmt /usr/local/bin/gofmt
+
+  #shellcheck disable=SC2016
+  $SUDO chown -R "$(whoami)": /usr/local/bin/go /usr/local/bin/gofmt
+}
+
 : "${OSD_FAMILY:="linux"}"
 : "${HOSTTYPE:="amd64"}"
 if [ "${HOSTTYPE}" = "x86_64" ]; then HOSTTYPE="amd64"; fi
 if [ "${HOSTTYPE}" = "aarch64" ]; then HOSTTYPE="arm64"; fi
 case "${HOSTTYPE}" in *86) HOSTTYPE=i386 ;; esac
 
-if command -v go >/dev/null; then
-  if go version | grep -q -F "go<< parameters.version >> "; then
-    echo "Binary already exists, skipping download."
-    exit 0
-  fi
-
-  echo "Found a different version of Go."
-  OSD_FAMILY="$(go env GOHOSTOS)"
-  HOSTTYPE="$(go env GOHOSTARCH)"
-
-  $SUDO rm -rf /usr/local/go
-  $SUDO install --owner="${USER}" -d /usr/local/go
+grep alpinelinux /etc/os-release
+if [ $? -eq 0 ]; then
+  alpine_install
+else
+  standard_install
 fi
-
-# Checking if Alpine is being used to update the tar options
-echo "Installing the requested version of Go."
-curl -O --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
-$SUDO tar xzf "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" -C /opt
-rm "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
-ln -s /opt/go/bin/go /usr/local/bin/go
-ln -s /opt/go/bin/gofmt /usr/local/bin/gofmt
-
-#shellcheck disable=SC2016
-$SUDO chown -R "$(whoami)": /usr/local/bin/go /usr/local/bin/gofmt

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -22,14 +22,11 @@ fi
 
 # Checking if Alpine is being used to update the tar options
 echo "Installing the requested version of Go."
-if grep -q 'Alpine Linux' /etc/os-release; then
-  curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" |
-    $SUDO tar -o --strip-components=1 -z -x -C /usr/local/go/
-else
-  curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" |
-    $SUDO tar --no-same-owner --strip-components=1 --gunzip -x -C /usr/local/go/
-fi
+curl -O --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
+$SUDO tar xzf go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz -C /opt/go
+rm go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz
+ln -s /opt/go/bin/go /usr/local/bin/go
+ln -s /opt/go/bin/gofmt /usr/local/bin/gofmt
 
 #shellcheck disable=SC2016
-echo 'export PATH=$PATH:/usr/local/go/bin' >>"$BASH_ENV"
-$SUDO chown -R "$(whoami)": /usr/local/go
+$SUDO chown -R "$(whoami)": /usr/local/bin/go /usr/local/bin/gofmt

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -22,7 +22,7 @@ fi
 
 # Checking if Alpine is being used to update the tar options
 echo "Installing the requested version of Go."
-if [[ $(grep '^NAME=' /etc/os-release | cut -d'=' -f2) = "Alpine Linux" ]]; then
+if [ $(grep 'Alpine Linux' /etc/os-release) ]; then
   curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" |
     $SUDO tar -o --strip-components=1 -z -x -C /usr/local/go/
 else

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -23,7 +23,7 @@ fi
 # Checking if Alpine is being used to update the tar options
 echo "Installing the requested version of Go."
 curl -O --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
-$SUDO tar xzf "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" -C /opt/go
+$SUDO tar xzf "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" -C /opt
 rm "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
 ln -s /opt/go/bin/go /usr/local/bin/go
 ln -s /opt/go/bin/gofmt /usr/local/bin/gofmt

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 function alpine_install {
-  cd /opt
+  cd /opt || exit 200
   apk add bash gcc musl-dev go
   wget "https://go.dev/dl/go${ORB_VAL_VERSION}.src.tar.gz"
   tar xzf "go${ORB_VAL_VERSION}.src.tar.gz"
   mv go "go${ORB_VAL_VERSION}"
-  cd "go${ORB_VAL_VERSION}/src"
+  cd "go${ORB_VAL_VERSION}/src" || exit 201
   ./make.bash
   apk del go
   ln -s "/opt/go${ORB_VAL_VERSION}/bin/go" /usr/local/bin/go

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -31,9 +31,9 @@ function standard_install {
   echo "Installing the requested version of Go."
   curl -O --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
   $SUDO tar xzf "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" -C /opt
-  rm "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
-  ln -s /opt/go/bin/go /usr/local/bin/go
-  ln -s /opt/go/bin/gofmt /usr/local/bin/gofmt
+  $SUDO rm "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
+  $SUDO ln -s /opt/go/bin/go /usr/local/bin/go
+  $SUDO ln -s /opt/go/bin/gofmt /usr/local/bin/gofmt
 
   #shellcheck disable=SC2016
   $SUDO chown -R "$(whoami)": /usr/local/bin/go /usr/local/bin/gofmt

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -22,7 +22,7 @@ fi
 
 # Checking if Alpine is being used to update the tar options
 TAR_OPTIONS="--no-same-owner --strip-components=1 --gunzip -x -C"
-if [[ $(cat /etc/os-release | grep '^NAME=' | cut -d'=' -f2) = "Alpine Linux" ]]; then
+if [[ $(grep '^NAME=' /etc/os-release | cut -d'=' -f2) = "Alpine Linux" ]]; then
   TAR_OPTIONS="-o --strip-components=1 -z -x -C"
 fi
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -28,7 +28,7 @@ fi
 
 echo "Installing the requested version of Go."
 curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" |
-  $SUDO tar "${TAR_OPTIONS}" /usr/local/go/
+  $SUDO tar ${TAR_OPTIONS} /usr/local/go/
 
 #shellcheck disable=SC2016
 echo 'export PATH=$PATH:/usr/local/go/bin' >>"$BASH_ENV"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -45,7 +45,7 @@ if [ "${HOSTTYPE}" = "x86_64" ]; then HOSTTYPE="amd64"; fi
 if [ "${HOSTTYPE}" = "aarch64" ]; then HOSTTYPE="arm64"; fi
 case "${HOSTTYPE}" in *86) HOSTTYPE=i386 ;; esac
 
-if [ grep alpinelinux /etc/os-release ]; then
+if grep alpinelinux /etc/os-release; then
   alpine_install
 else
   standard_install

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -22,7 +22,7 @@ fi
 
 # Checking if Alpine is being used to update the tar options
 echo "Installing the requested version of Go."
-if [ "$(grep 'Alpine Linux' /etc/os-release)" ]; then
+if [ "$(grep -q 'Alpine Linux' /etc/os-release)" ]; then
   curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" |
     $SUDO tar -o --strip-components=1 -z -x -C /usr/local/go/
 else

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -3,14 +3,14 @@
 function alpine_install {
   cd /opt
   apk add bash gcc musl-dev go
-  wget https://go.dev/dl/go${ORB_VAL_VERSION}.src.tar.gz
-  tar xzf go${ORB_VAL_VERSION}.src.tar.gz
-  mv go go${ORB_VAL_VERSION}
-  cd go${ORB_VAL_VERSION}/src
+  wget "https://go.dev/dl/go${ORB_VAL_VERSION}.src.tar.gz"
+  tar xzf "go${ORB_VAL_VERSION}.src.tar.gz"
+  mv go "go${ORB_VAL_VERSION}"
+  cd "go${ORB_VAL_VERSION}/src"
   ./make.bash
   apk del go
-  ln -s /opt/go${ORB_VAL_VERSION}/bin/go /usr/local/bin/go
-  ln -s /opt/go${ORB_VAL_VERSION}/bin/gofmt /usr/local/bin/gofmt
+  ln -s "/opt/go${ORB_VAL_VERSION}/bin/go" /usr/local/bin/go
+  ln -s "/opt/go${ORB_VAL_VERSION}/bin/gofmt" /usr/local/bin/gofmt
 }
 
 function standard_install {

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -23,8 +23,8 @@ fi
 # Checking if Alpine is being used to update the tar options
 echo "Installing the requested version of Go."
 curl -O --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
-$SUDO tar xzf go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz -C /opt/go
-rm go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz
+$SUDO tar xzf "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" -C /opt/go
+rm "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
 ln -s /opt/go/bin/go /usr/local/bin/go
 ln -s /opt/go/bin/gofmt /usr/local/bin/gofmt
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -9,8 +9,8 @@ function alpine_install {
   cd "go${ORB_VAL_VERSION}/src" || exit 201
   ./make.bash
   apk del go
-  ln -s "/opt/go${ORB_VAL_VERSION}/bin/go" /usr/local/bin/go
-  ln -s "/opt/go${ORB_VAL_VERSION}/bin/gofmt" /usr/local/bin/gofmt
+  ln -sf "/opt/go${ORB_VAL_VERSION}/bin/go" /usr/local/bin/go
+  ln -sf "/opt/go${ORB_VAL_VERSION}/bin/gofmt" /usr/local/bin/gofmt
 }
 
 function standard_install {
@@ -32,8 +32,8 @@ function standard_install {
   curl -O --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
   $SUDO tar xzf "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" -C /opt
   $SUDO rm "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
-  $SUDO ln -s /opt/go/bin/go /usr/local/bin/go
-  $SUDO ln -s /opt/go/bin/gofmt /usr/local/bin/gofmt
+  $SUDO ln -sf /opt/go/bin/go /usr/local/bin/go
+  $SUDO ln -sf /opt/go/bin/gofmt /usr/local/bin/gofmt
 
   #shellcheck disable=SC2016
   $SUDO chown -R "$(whoami)": /usr/local/bin/go /usr/local/bin/gofmt

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -21,7 +21,7 @@ if command -v go >/dev/null; then
 fi
 
 # Checking if Alpine is being used to update the tar options
-TAR_OPTIONS=(--no-same-owner --strip-components)1 --gunzip -x -C)
+TAR_OPTIONS=(--no-same-owner --strip-components=1 --gunzip -x -C)
 if [[ $(grep '^NAME=' /etc/os-release | cut -d'=' -f2) = "Alpine Linux" ]]; then
   TAR_OPTIONS=(-o --strip-components=1 -z -x -C)
 fi

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -4,28 +4,32 @@
 : "${HOSTTYPE:="amd64"}"
 if [ "${HOSTTYPE}" = "x86_64" ]; then HOSTTYPE="amd64"; fi
 if [ "${HOSTTYPE}" = "aarch64" ]; then HOSTTYPE="arm64"; fi
-case "${HOSTTYPE}" in *86 ) HOSTTYPE=i386 ;; esac
+case "${HOSTTYPE}" in *86) HOSTTYPE=i386 ;; esac
 
 if command -v go >/dev/null; then
-    if go version | grep -q -F "go<< parameters.version >> "; then
+  if go version | grep -q -F "go<< parameters.version >> "; then
     echo "Binary already exists, skipping download."
     exit 0
-    fi
+  fi
 
-    echo "Found a different version of Go."
-    OSD_FAMILY="$(go env GOHOSTOS)"
-    HOSTTYPE="$(go env GOHOSTARCH)"
+  echo "Found a different version of Go."
+  OSD_FAMILY="$(go env GOHOSTOS)"
+  HOSTTYPE="$(go env GOHOSTARCH)"
 
-    $SUDO rm -rf /usr/local/go
-    $SUDO install --owner="${USER}" -d /usr/local/go
+  $SUDO rm -rf /usr/local/go
+  $SUDO install --owner="${USER}" -d /usr/local/go
+fi
+
+# Checking if Alpine is being used to update the tar options
+TAR_OPTIONS="--no-same-owner --strip-components=1 --gunzip -x -C"
+if [[ $(cat /etc/os-release | grep '^NAME=' | cut -d'=' -f2) = "Alpine Linux" ]]; then
+  TAR_OPTIONS="-o --strip-components=1 -z -x -C"
 fi
 
 echo "Installing the requested version of Go."
-
-curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" \
-| $SUDO tar --no-same-owner --strip-components=1 --gunzip -x -C /usr/local/go/
+curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" |
+  $SUDO tar "${TAR_OPTIONS}" /usr/local/go/
 
 #shellcheck disable=SC2016
-echo 'export PATH=$PATH:/usr/local/go/bin' >> "$BASH_ENV"
+echo 'export PATH=$PATH:/usr/local/go/bin' >>"$BASH_ENV"
 $SUDO chown -R "$(whoami)": /usr/local/go
-

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -26,6 +26,7 @@ function standard_install {
 
     $SUDO rm -rf /usr/local/go
     $SUDO install --owner="${USER}" -d /usr/local/go
+    $SUDO rm -rf /opt/go
   fi
 
   echo "Installing the requested version of Go."

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -45,8 +45,7 @@ if [ "${HOSTTYPE}" = "x86_64" ]; then HOSTTYPE="amd64"; fi
 if [ "${HOSTTYPE}" = "aarch64" ]; then HOSTTYPE="arm64"; fi
 case "${HOSTTYPE}" in *86) HOSTTYPE=i386 ;; esac
 
-grep alpinelinux /etc/os-release
-if [ $? -eq 0 ]; then
+if [ grep alpinelinux /etc/os-release ]; then
   alpine_install
 else
   standard_install

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -22,7 +22,7 @@ fi
 
 # Checking if Alpine is being used to update the tar options
 echo "Installing the requested version of Go."
-if [ $(grep 'Alpine Linux' /etc/os-release) ]; then
+if [ "$(grep 'Alpine Linux' /etc/os-release)" ]; then
   curl --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" |
     $SUDO tar -o --strip-components=1 -z -x -C /usr/local/go/
 else


### PR DESCRIPTION
Fixes #97 .

This PR allows the go-orb to support Alpine containers.
It was designed to be compatible with the most recent versions of go (tested v13+).
The PR updated the install.sh script by adding a logic specific to Alpine which downloads some dependencies to compile the Go compiler and installs the specified version.