### PR TITLE
Properly check boolean flags in test command

### DIFF
--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -20,7 +20,7 @@ fi
 
 COVER_PROFILE=$(eval echo "$ORB_EVAL_COVER_PROFILE")
 
-if [ -n "$ORB_VAL_RACE" ]; then
+if [ "$ORB_VAL_RACE" != "false" ]; then
   set -- "$@" -race
   ORB_VAL_COVER_MODE=atomic
 fi
@@ -29,11 +29,11 @@ if [ "$ORB_VAL_FAILFAST" != "false" ]; then
   set -- "$@" -failfast
 fi
 
-if [ -n "$ORB_VAL_SHORT" ]; then
+if [ "$ORB_VAL_SHORT" != "false" ]; then
   set -- "$@" -short
 fi
 
-if [ -n "$ORB_VAL_VERBOSE" ]; then
+if [ "$ORB_VAL_VERBOSE" != "false" ]; then
   set -- "$@" -v
 fi
 

--- a/src/scripts/test.sh
+++ b/src/scripts/test.sh
@@ -20,20 +20,20 @@ fi
 
 COVER_PROFILE=$(eval echo "$ORB_EVAL_COVER_PROFILE")
 
-if [ "$ORB_VAL_RACE" != "false" ]; then
+if [ "$ORB_VAL_RACE" -eq 1 ]; then
   set -- "$@" -race
   ORB_VAL_COVER_MODE=atomic
 fi
 
-if [ "$ORB_VAL_FAILFAST" != "false" ]; then
+if [ "$ORB_VAL_FAILFAST" -eq 1 ]; then
   set -- "$@" -failfast
 fi
 
-if [ "$ORB_VAL_SHORT" != "false" ]; then
+if [ "$ORB_VAL_SHORT" -eq 1 ]; then
   set -- "$@" -short
 fi
 
-if [ "$ORB_VAL_VERBOSE" != "false" ]; then
+if [ "$ORB_VAL_VERBOSE" -eq 1 ]; then
   set -- "$@" -v
 fi
 


### PR DESCRIPTION
Previous code only checked if the env variables was set. As it is always set, the race, short and verbose options where always on.