### PR TITLE
chore: BREAKING CHANGE install goreleaser v2 instead of v1

### DIFF
--- a/src/scripts/install-goreleaser.sh
+++ b/src/scripts/install-goreleaser.sh
@@ -2,5 +2,5 @@
 
 GO_STR_VERSION="$(echo "${GO_STR_VERSION}"| circleci env subst)"
 
-go install github.com/goreleaser/goreleaser@"${GO_STR_VERSION}"
+go install github.com/goreleaser/goreleaser/v2@"${GO_STR_VERSION}"
 goreleaser --version


### PR DESCRIPTION
Goreleaser (likely) ended updates for v1 and has since moved onto v2. https://goreleaser.com/blog/goreleaser-v1.26/

As this is a breaking change due to upstream dependencies changing perhaps a major version (3.0.0) of the go orb should be released.