### PR TITLE
chore: BREAKING CHANGE install goreleaser v2 instead of v1

### DIFF
--- a/src/scripts/install-goreleaser.sh
+++ b/src/scripts/install-goreleaser.sh
@@ -2,5 +2,5 @@
 
 GO_STR_VERSION="$(echo "${GO_STR_VERSION}"| circleci env subst)"
 
-go install github.com/goreleaser/goreleaser@"${GO_STR_VERSION}"
+go install github.com/goreleaser/goreleaser/v2@"${GO_STR_VERSION}"
 goreleaser --version

--- a/tests/.goreleaser.yaml
+++ b/tests/.goreleaser.yaml
@@ -1,10 +1,12 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
 
-# The lines bellow are called `modelines`. See `:help modeline`
+# The lines below are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/need to use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
 
 before:
   hooks:
@@ -22,7 +24,7 @@ builds:
       - darwin
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -34,7 +36,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 changelog:
   sort: asc


### PR DESCRIPTION
From https://github.com/CircleCI-Public/go-orb/pull/103

Goreleaser (likely) ended updates for v1 and has since moved onto v2. https://goreleaser.com/blog/goreleaser-v1.26/

As this is a breaking change due to upstream dependencies changing perhaps a major version (3.0.0) of the go orb should be released.