### PR TITLE
Use ~ for dynamic home path in caches

### DIFF
--- a/src/commands/save-build-cache.yml
+++ b/src/commands/save-build-cache.yml
@@ -7,7 +7,7 @@ parameters:
   path:
     description: "Path to cache."
     type: string
-    default: "/home/circleci/.cache/go-build"
+    default: ~/.cache/go-build
 steps:
   - save_cache:
       key: v1-<< parameters.key >>-go-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "go.sum" }}-{{ epoch | round "72h" }}

--- a/src/commands/save-golangci-lint-cache.yml
+++ b/src/commands/save-golangci-lint-cache.yml
@@ -7,7 +7,7 @@ parameters:
   path:
     description: "Path to cache."
     type: string
-    default: "/home/circleci/.cache/golangci-lint"
+    default: ~/.cache/golangci-lint
 steps:
   - save_cache:
       key: v1-<< parameters.key >>-golangci-lint-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "go.sum" }}-{{ epoch | round "72h" }}

--- a/src/commands/save-mod-cache.yml
+++ b/src/commands/save-mod-cache.yml
@@ -8,7 +8,7 @@ parameters:
     description: "Path to cache."
     type: string
     # /home/circleci/go is the GOPATH in the cimg/go Docker image
-    default: "/home/circleci/go/pkg/mod"
+    default: ~/go/pkg/mod
 steps:
   - save_cache:
       key: v1-<< parameters.key >>-go-mod-{{ arch }}-{{ checksum "go.sum" }}

--- a/src/commands/with-cache.yml
+++ b/src/commands/with-cache.yml
@@ -15,7 +15,7 @@ parameters:
   build-path:
     description: "Location of go-build cache."
     type: string
-    default: "/home/circleci/.cache/go-build"
+    default: ~/.cache/go-build
   mod:
     description: |
       Whether to use go module cache. If most of your dependencies are public, it is faster to use the public
@@ -25,7 +25,7 @@ parameters:
   mod-path:
     description: "Location of go module cache."
     type: string
-    default: "/home/circleci/go/pkg/mod"
+    default: ~/go/pkg/mod
   golangci-lint:
     description: "Whether to use golangci-lint cache. Useful only in steps with linting, so defaults to false."
     type: boolean
@@ -33,7 +33,7 @@ parameters:
   golangci-lint-path:
     description: "Location of golangci-lint cache."
     type: string
-    default: "/home/circleci/.cache/golangci-lint"
+    default: ~/.cache/golangci-lint
 steps:
   - when:
       condition: << parameters.build >>


### PR DESCRIPTION
- This will make the caching work out of the box for non-cimg images