### PR TITLE
Support customising the checksum template

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -114,6 +114,7 @@ jobs:
           key: "integration"
           mod: true
           golangci-lint: true
+          checksum: '{{ checksum "go.mod" }}-{{ checksum "go.sum" }}'
           steps:
             - go/mod-download
             - run: go version && go build ./...

--- a/src/commands/load-build-cache.yml
+++ b/src/commands/load-build-cache.yml
@@ -4,7 +4,11 @@ parameters:
     description: "User-configurable component for cache key. Useful for avoiding collisions in complex workflows."
     type: string
     default: ""
+  checksum:
+    description: "Checksum template instruction"
+    type: string
+    default: '{{ checksum "go.sum" }}'
 steps:
   - restore_cache:
       keys:
-        - v1-<< parameters.key >>-go-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "go.sum" }}-{{ epoch | round "72h" }}
+        - v1-<< parameters.key >>-go-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-<< parameters.checksum >>-{{ epoch | round "72h" }}

--- a/src/commands/load-golangci-lint-cache.yml
+++ b/src/commands/load-golangci-lint-cache.yml
@@ -4,7 +4,11 @@ parameters:
     description: "User-configurable component for cache key. Useful for avoiding collisions in complex workflows."
     type: string
     default: ""
+  checksum:
+    description: "Checksum template instruction"
+    type: string
+    default: '{{ checksum "go.sum" }}'
 steps:
   - restore_cache:
       keys:
-        - v1-<< parameters.key >>-golangci-lint-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "go.sum" }}-{{ epoch | round "72h" }}
+        - v1-<< parameters.key >>-golangci-lint-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-<< parameters.checksum >>-{{ epoch | round "72h" }}

--- a/src/commands/load-mod-cache.yml
+++ b/src/commands/load-mod-cache.yml
@@ -4,7 +4,11 @@ parameters:
     description: "User-configurable component for cache key. Useful for avoiding collisions in complex workflows."
     type: string
     default: ""
+  checksum:
+    description: "Checksum template instruction"
+    type: string
+    default: '{{ checksum "go.sum" }}'
 steps:
   - restore_cache:
       keys:
-        - v1-<< parameters.key >>-go-mod-{{ arch }}-{{ checksum "go.sum" }}
+        - v1-<< parameters.key >>-go-mod-{{ arch }}-<< parameters.checksum >>

--- a/src/commands/save-build-cache.yml
+++ b/src/commands/save-build-cache.yml
@@ -8,8 +8,12 @@ parameters:
     description: "Path to cache."
     type: string
     default: ~/.cache/go-build
+  checksum:
+    description: "Checksum template instruction"
+    type: string
+    default: '{{ checksum "go.sum" }}'
 steps:
   - save_cache:
-      key: v1-<< parameters.key >>-go-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "go.sum" }}-{{ epoch | round "72h" }}
+      key: v1-<< parameters.key >>-go-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-<< parameters.checksum >>-{{ epoch | round "72h" }}
       paths:
         - << parameters.path >>

--- a/src/commands/save-golangci-lint-cache.yml
+++ b/src/commands/save-golangci-lint-cache.yml
@@ -8,9 +8,12 @@ parameters:
     description: "Path to cache."
     type: string
     default: ~/.cache/golangci-lint
+  checksum:
+    description: "Checksum template instruction"
+    type: string
+    default: '{{ checksum "go.sum" }}'
 steps:
   - save_cache:
-      key: v1-<< parameters.key >>-golangci-lint-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "go.sum" }}-{{ epoch | round "72h" }}
+      key: v1-<< parameters.key >>-golangci-lint-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-<< parameters.checksum >>-{{ epoch | round "72h" }}
       paths:
         - << parameters.path >>
-

--- a/src/commands/save-mod-cache.yml
+++ b/src/commands/save-mod-cache.yml
@@ -7,10 +7,13 @@ parameters:
   path:
     description: "Path to cache."
     type: string
-    # /home/circleci/go is the GOPATH in the cimg/go Docker image
     default: ~/go/pkg/mod
+  checksum:
+    description: "Checksum template instruction"
+    type: string
+    default: '{{ checksum "go.sum" }}'
 steps:
   - save_cache:
-      key: v1-<< parameters.key >>-go-mod-{{ arch }}-{{ checksum "go.sum" }}
+      key: v1-<< parameters.key >>-go-mod-{{ arch }}-<< parameters.checksum >>
       paths:
         - << parameters.path >>

--- a/src/commands/with-cache.yml
+++ b/src/commands/with-cache.yml
@@ -34,38 +34,48 @@ parameters:
     description: "Location of golangci-lint cache."
     type: string
     default: ~/.cache/golangci-lint
+  checksum:
+    description: "Checksum template instruction"
+    type: string
+    default: '{{ checksum "go.sum" }}'
 steps:
   - when:
       condition: << parameters.build >>
       steps:
         - load-build-cache:
-            key: << parameters.key >>
+            key: '<< parameters.key >>'
+            checksum: '<< parameters.checksum >>'
   - when:
       condition: << parameters.mod >>
       steps:
         - load-mod-cache:
-            key: << parameters.key >>
+            key: '<< parameters.key >>'
+            checksum: '<< parameters.checksum >>'
   - when:
       condition: << parameters.golangci-lint >>
       steps:
         - load-golangci-lint-cache:
-            key: << parameters.key >>
+            key: '<< parameters.key >>'
+            checksum: '<< parameters.checksum >>'
   - steps: << parameters.steps >>
   - when:
       condition: << parameters.build >>
       steps:
         - save-build-cache:
-            key: << parameters.key >>
-            path: << parameters.build-path >>
+            key: '<< parameters.key >>'
+            checksum: '<< parameters.checksum >>'
+            path: '<< parameters.build-path >>'
   - when:
       condition: << parameters.mod >>
       steps:
         - save-mod-cache:
-            key: << parameters.key >>
-            path: << parameters.mod-path >>
+            key: '<< parameters.key >>'
+            checksum: '<< parameters.key >>'
+            path: '<< parameters.mod-path >>'
   - when:
       condition: << parameters.golangci-lint >>
       steps:
         - save-golangci-lint-cache:
-            key: << parameters.key >>
-            path: << parameters.golangci-lint-path >>
+            key: '<< parameters.key >>'
+            checksum: '<< parameters.checksum >>'
+            path: '<< parameters.golangci-lint-path >>'


### PR DESCRIPTION
- In cases where you might have more than one file you wish to consider for the cache checksum, this allows you to specify those files:
```yaml
go/with-cache:
  checksum: '{{ checksum "go.sum" }}-{{ checksum "tools/go.sum" }}'
  steps:
     - ...
```
- Also if folks generally wish to specify a different file it helps:
```yaml
go/with-cache:
  checksum: '{{ checksum "my/other/go.sum" }}'
  steps:
     - ...
```

Previous attempt by community member here: https://github.com/CircleCI-Public/go-orb/pull/85. I've tried to make a more general purpose solution to serve more needs here.