### PR TITLE
Update Mac resource class in test-deploy.yml

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -27,9 +27,9 @@ executors:
     docker:
       - image: cimg/go:1.23
   mac:
-    resource_class: m2pro.medium
+    resource_class: m4pro.medium
     macos:
-      xcode: "16.2.0"
+      xcode: 26.3.0
   ubuntu_machine:
     resource_class: medium
     machine:


### PR DESCRIPTION
Updating the Mac resource class to be M4 since M2s are no longer available.