### PR TITLE
fix: do not override GITHUB_TOKEN during goreleaser release

### DIFF
--- a/src/commands/goreleaser-release.yml
+++ b/src/commands/goreleaser-release.yml
@@ -30,7 +30,7 @@ steps:
   - run:
       name: "Build and release Go Binaries to GitHub with GoReleaser"
       environment:
-        GITHUB_TOKEN: << parameters.github-token >>
+        GO_ENV_VAR_NAME_GITHUB_TOKEN: << parameters.github-token >>
         GO_BOOL_VALIDATE_YAML: << parameters.validate-yaml >>
         GO_BOOL_PUBLISH_RELEASE: << parameters.publish-release >>
         GO_EVAL_PROJECT_PATH: << parameters.project-path >>

--- a/src/scripts/goreleaser-release.sh
+++ b/src/scripts/goreleaser-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GITHUB_TOKEN="$(echo "\$$GITHUB_TOKEN" | circleci env subst)"
+GITHUB_TOKEN="$(echo "\$$GO_ENV_VAR_NAME_GITHUB_TOKEN" | circleci env subst)"
 GO_EVAL_PROJECT_PATH="$(eval echo "${GO_EVAL_PROJECT_PATH}")"
 
 # Change to directory containing project files


### PR DESCRIPTION
In the case that a context with the Github token stored in an environment variable named GITHUB_TOKEN is passed to the job, the goreleaser-release command will overwrite the GITHUB_TOKEN environment variable with the value GITHUB_TOKEN before attempting to expand it using the circleci cli. Since the environment variable no longer points to a valid token value, the release will fail.

Instead, this commit uses a placeholder environment variable in the command's environment to avoid overwriting the GITHUB_TOKEN value and correctly sets the GITHUB_TOKEN environment variable to the provided environment variable name's value.