### PR TITLE
fix: implemented timeouts and retries for the go compiler and goreleaser binaries

### DIFF
--- a/src/scripts/install-goreleaser.sh
+++ b/src/scripts/install-goreleaser.sh
@@ -2,6 +2,27 @@
 
 set -euo pipefail
 
+RETRY_ATTEMPTS=3
+RETRY_DELAY=5
+
+function retry {
+  local attempt=1
+  while [ "$attempt" -le "$RETRY_ATTEMPTS" ]; do
+    echo "Attempt $attempt of $RETRY_ATTEMPTS: $*" >&2
+    if "$@"; then
+      return 0
+    fi
+    echo "Attempt $attempt failed." >&2
+    attempt=$((attempt + 1))
+    if [ "$attempt" -le "$RETRY_ATTEMPTS" ]; then
+      echo "Retrying in ${RETRY_DELAY} seconds..." >&2
+      sleep "$RETRY_DELAY"
+    fi
+  done
+  echo "All $RETRY_ATTEMPTS attempts failed." >&2
+  return 1
+}
+
 function alpine_install_curl() {
   apk add curl
 }
@@ -37,11 +58,11 @@ download_goreleaser() {
   fi
   if [ -z "${GO_STR_VERSION:-}" ]; then
     # Taken from https://goreleaser.com/install/#bash-script
-    GO_STR_VERSION="$(curl -sf https://goreleaser.com/static/latest)"
+    GO_STR_VERSION="$(retry curl -sf --connect-timeout 30 --max-time 30 https://goreleaser.com/static/latest)"
   fi
   URL="https://github.com/goreleaser/goreleaser/releases/download/${GO_STR_VERSION}/goreleaser_${os}_${architecture}.${file_extension}"
   echo "Downloading goreleaser from ${URL}"
-  if ! curl --location "${URL}" --output "${TMP_FILE}" &>/dev/null; then
+  if ! retry curl --fail --location "${URL}" --output "${TMP_FILE}" --connect-timeout 30 --max-time 600; then
     echo "Failed to download goreleaser"
     exit 1
   fi

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,9 +1,30 @@
 #!/usr/bin/env bash
 
+RETRY_ATTEMPTS=3
+RETRY_DELAY=5
+
+function retry {
+  local attempt=1
+  while [ "$attempt" -le "$RETRY_ATTEMPTS" ]; do
+    echo "Attempt $attempt of $RETRY_ATTEMPTS: $*" >&2
+    if "$@"; then
+      return 0
+    fi
+    echo "Attempt $attempt failed." >&2
+    attempt=$((attempt + 1))
+    if [ "$attempt" -le "$RETRY_ATTEMPTS" ]; then
+      echo "Retrying in ${RETRY_DELAY} seconds..." >&2
+      sleep "$RETRY_DELAY"
+    fi
+  done
+  echo "All $RETRY_ATTEMPTS attempts failed." >&2
+  return 1
+}
+
 function alpine_install {
   cd /opt || exit 200
   apk add bash gcc musl-dev go
-  wget "https://go.dev/dl/go${ORB_VAL_VERSION}.src.tar.gz"
+  retry wget --timeout=300 "https://go.dev/dl/go${ORB_VAL_VERSION}.src.tar.gz"
   tar xzf "go${ORB_VAL_VERSION}.src.tar.gz"
   mv go "go${ORB_VAL_VERSION}"
   cd "go${ORB_VAL_VERSION}/src" || exit 201
@@ -30,7 +51,7 @@ function standard_install {
   fi
 
   echo "Installing the requested version of Go."
-  curl -O --fail --location -sS "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
+  retry curl -O --fail --location -sS --connect-timeout 30 --max-time 300 "https://dl.google.com/go/go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
   $SUDO tar xzf "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz" -C /opt
   $SUDO rm "go${ORB_VAL_VERSION}.${OSD_FAMILY}-${HOSTTYPE}.tar.gz"
   $SUDO ln -sf /opt/go/bin/go /usr/local/bin/go


### PR DESCRIPTION
# Description
Introduced a centralized `retry` function in `install.sh` and `install-goreleaser.sh` to wrap network-dependent commands. This function manages multiple attempts with a configurable delay and adds explicit timeouts to `curl` and `wget` calls.

# Reasons
* **Network Resilience:** Build environments often experience transient "blips" or timeouts when connecting to external package mirrors (like `go.dev` or `github.com`). 
* **Reliable CI/CD:** By implementing a 3-attempt retry loop with a 5-second delay, we significantly reduce the frequency of pipeline failures caused by intermittent download errors.
* **Fail-fast Timeouts:** Added `--connect-timeout` and `--max-time` parameters to ensure that hanging connections are terminated quickly rather than stalling the build process indefinitely.

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)