### PR TITLE
feat: include GOEXPERIMENT in build cache keys

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -213,6 +213,20 @@ jobs:
       - go/install:
           version: 1.16.4
       - run: go version && go build ./...
+  int-test-goexperiment-cache:
+    executor:
+      name: go/default
+      tag: "1.23"
+    environment:
+      GOEXPERIMENT: boringcrypto
+    steps:
+      - run:
+          name: "Check out sample project."
+          command: git clone https://github.com/CircleCI-Public/circleci-demo-go.git ~/project
+      - go/with-cache:
+          key: "goexperiment"
+          steps:
+            - run: go version && go build ./...
   go-test-default:
     executor:
       name: go/default
@@ -293,6 +307,8 @@ workflows:
           filters: *filters
       - int-test-vm-arm64:
           filters: *filters
+      - int-test-goexperiment-cache:
+          filters: *filters
       - go-test-default:
           filters: *filters
       - int-test-gotestsum-1-test:
@@ -323,5 +339,6 @@ workflows:
             - int-test-goreleaser-install-alpine-no-curl
             - int-test-goreleaser-install-pinned-version
             - int-test-goreleaser-release
+            - int-test-goexperiment-cache
           context: orb-publisher
           filters: *release-filters

--- a/src/commands/load-build-cache.yml
+++ b/src/commands/load-build-cache.yml
@@ -11,4 +11,4 @@ parameters:
 steps:
   - restore_cache:
       keys:
-        - v1-<< parameters.key >>-go-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-<< parameters.checksum >>-{{ epoch | round "72h" }}
+        - v1-<< parameters.key >>-go-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Environment.GOEXPERIMENT }}-<< parameters.checksum >>-{{ epoch | round "72h" }}

--- a/src/commands/load-golangci-lint-cache.yml
+++ b/src/commands/load-golangci-lint-cache.yml
@@ -11,4 +11,4 @@ parameters:
 steps:
   - restore_cache:
       keys:
-        - v1-<< parameters.key >>-golangci-lint-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-<< parameters.checksum >>-{{ epoch | round "72h" }}
+        - v1-<< parameters.key >>-golangci-lint-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Environment.GOEXPERIMENT }}-<< parameters.checksum >>-{{ epoch | round "72h" }}

--- a/src/commands/save-build-cache.yml
+++ b/src/commands/save-build-cache.yml
@@ -14,6 +14,6 @@ parameters:
     default: '{{ checksum "go.sum" }}'
 steps:
   - save_cache:
-      key: v1-<< parameters.key >>-go-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-<< parameters.checksum >>-{{ epoch | round "72h" }}
+      key: v1-<< parameters.key >>-go-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Environment.GOEXPERIMENT }}-<< parameters.checksum >>-{{ epoch | round "72h" }}
       paths:
         - << parameters.path >>

--- a/src/commands/save-golangci-lint-cache.yml
+++ b/src/commands/save-golangci-lint-cache.yml
@@ -14,6 +14,6 @@ parameters:
     default: '{{ checksum "go.sum" }}'
 steps:
   - save_cache:
-      key: v1-<< parameters.key >>-golangci-lint-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-<< parameters.checksum >>-{{ epoch | round "72h" }}
+      key: v1-<< parameters.key >>-golangci-lint-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Environment.GOEXPERIMENT }}-<< parameters.checksum >>-{{ epoch | round "72h" }}
       paths:
         - << parameters.path >>


### PR DESCRIPTION
## Summary
- Include `GOEXPERIMENT` env var in build and golangci-lint cache keys so different experiment flags produce separate caches
- Add integration test job with `GOEXPERIMENT=boringcrypto` to verify cache key resolution