### PR TITLE
feat!: bump default Go version 1.16.5 → 1.26.3 (PIE-6)

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -4,7 +4,7 @@ parameters:
   version:
     description: "The Go version."
     type: string
-    default: "1.16.5"
+    default: "1.26.3"
   cache:
     description: Whether or not to cache the binary.
     type: boolean


### PR DESCRIPTION
## Summary

- Bumps the `version` parameter default in `commands/install.yml` from `1.16.5` to `1.24.4`
- Go 1.16.5 reached end-of-life in 2022; 1.24.x is the current supported release branch

## Breaking change

Users who relied on the `1.16.5` default without pinning an explicit `version` will now get Go 1.24.4. Pin `version: "1.16.5"` (or your desired version) to preserve the old behaviour.

## Migration guide (v→v+1)

```yaml
# Before (implicit default):
- go/install

# After — pin the old version to keep it, or omit to use the new default:
- go/install:
    version: "1.16.5"   # explicit pin if you need the old version
```

Closes PIE-6