### PR TITLE
with-cache: fix checksum param when 'mod: true'

### DIFF
--- a/src/commands/with-cache.yml
+++ b/src/commands/with-cache.yml
@@ -70,7 +70,7 @@ steps:
       steps:
         - save-mod-cache:
             key: '<< parameters.key >>'
-            checksum: '<< parameters.key >>'
+            checksum: '<< parameters.checksum >>'
             path: '<< parameters.mod-path >>'
   - when:
       condition: << parameters.golangci-lint >>


### PR DESCRIPTION
## PROBLEM

`with-cache`'s `save-mod-cache` step passed the key parameter into the checksum slot instead of the checksum parameter ([src/commands/with-cache.yml:73](https://github.com/CircleCI-Public/go-orb/blob/09ea6542c4b31bacff321345992086242e4598ee/src/commands/with-cache.yml#L73)). Since `load-mod-cache` correctly used the real `go.sum` checksum but `save-mod-cache` did not, the save and restore cache keys could never match. As a result, with `mod: true`, the Go module cache was never actually restored, so every job did a cold/full go mod download, and the one-time save under the broken key was a no-op on later runs.

As a workaround, the user could do something like the following. Instead of 

```yaml
       - go/mod-download
       - go/with-cache:
           mod: true
           steps:
             - ... # some command that downloads other go mods
```

They would need

```yaml
      - restore_cache:
          keys:
            - v1-go-mod-{{ arch }}-{{ checksum "go.sum" }}
       - go/mod-download
       - go/with-cache:
           steps:
             - run: ...
      - save_cache:
          key: v1-go-mod-{{ arch }}-{{ checksum "go.sum" }}
          paths:
            - ~/go/pkg/mod
```

## SOLUTION

Pass `checksum: '<< parameters.checksum >>'` to `save-mod-cache` (matching `load-mod-cache`), so save and restore compute the same `go.sum`-based cache key. The module cache now actually persists across runs and invalidates correctly when go.sum changes.